### PR TITLE
Add support for non-square render resolutions (width != height)

### DIFF
--- a/examples/demo_deform.py
+++ b/examples/demo_deform.py
@@ -77,7 +77,7 @@ def main():
     model = Model(args.template_mesh).cuda()
     transform = sr.LookAt(viewing_angle=15)
     lighting = sr.Lighting()
-    rasterizer = sr.SoftRasterizer(image_size=64, sigma_val=1e-4, aggr_func_rgb='hard')
+    rasterizer = sr.SoftRasterizer(image_size=(64, 64), sigma_val=1e-4, aggr_func_rgb='hard')
 
     # read training images and camera poses
     images = np.load(args.filename_input).astype('float32') / 255.

--- a/soft_renderer/cuda/soft_rasterize_cuda.cpp
+++ b/soft_renderer/cuda/soft_rasterize_cuda.cpp
@@ -13,7 +13,8 @@ std::vector<at::Tensor> forward_soft_rasterize_cuda(
         at::Tensor faces_info,
         at::Tensor aggrs_info,
         at::Tensor soft_colors,
-        int image_size,
+        int image_width,
+        int image_height,
         float near,
         float far,
         float eps,
@@ -36,7 +37,8 @@ std::vector<at::Tensor> backward_soft_rasterize_cuda(
         at::Tensor grad_faces,
         at::Tensor grad_textures,
         at::Tensor grad_soft_colors,
-        int image_size,
+        int image_width,
+        int image_height,
         float near,
         float far,
         float eps,
@@ -55,14 +57,14 @@ std::vector<at::Tensor> backward_soft_rasterize_cuda(
 #define CHECK_CONTIGUOUS(x) TORCH_CHECK(x.is_contiguous(), #x " must be contiguous")
 #define CHECK_INPUT(x) CHECK_CUDA(x); CHECK_CONTIGUOUS(x)
 
-
 std::vector<at::Tensor> forward_soft_rasterize(
         at::Tensor faces,
         at::Tensor textures,
         at::Tensor faces_info,
         at::Tensor aggrs_info,
         at::Tensor soft_colors,
-        int image_size,
+        int image_width,
+        int image_height,
         float near,
         float far,
         float eps,
@@ -81,12 +83,12 @@ std::vector<at::Tensor> forward_soft_rasterize(
     CHECK_INPUT(aggrs_info);
     CHECK_INPUT(soft_colors);
 
-    return forward_soft_rasterize_cuda(faces, textures, 
-                                       faces_info, aggrs_info, 
-                                       soft_colors, 
-                                       image_size, near, far, eps, 
+    return forward_soft_rasterize_cuda(faces, textures,
+                                       faces_info, aggrs_info,
+                                       soft_colors,
+                                       image_width, image_height, near, far, eps,
                                        sigma_val, func_id_dist, dist_eps,
-                                       gamma_val, func_id_rgb, func_id_alpha, 
+                                       gamma_val, func_id_rgb, func_id_alpha,
                                        texture_sample_type, double_side);
 }
 
@@ -100,7 +102,8 @@ std::vector<at::Tensor> backward_soft_rasterize(
         at::Tensor grad_faces,
         at::Tensor grad_textures,
         at::Tensor grad_soft_colors,
-        int image_size,
+        int image_width,
+        int image_height,
         float near,
         float far,
         float eps,
@@ -122,12 +125,12 @@ std::vector<at::Tensor> backward_soft_rasterize(
     CHECK_INPUT(grad_textures);
     CHECK_INPUT(grad_soft_colors);
 
-    return backward_soft_rasterize_cuda(faces, textures, soft_colors, 
-                                        faces_info, aggrs_info, 
-                                        grad_faces, grad_textures, grad_soft_colors, 
-                                        image_size, near, far, eps, 
+    return backward_soft_rasterize_cuda(faces, textures, soft_colors,
+                                        faces_info, aggrs_info,
+                                        grad_faces, grad_textures, grad_soft_colors,
+                                        image_width, image_height, near, far, eps,
                                         sigma_val, func_id_dist, dist_eps,
-                                        gamma_val, func_id_rgb, func_id_alpha, 
+                                        gamma_val, func_id_rgb, func_id_alpha,
                                         texture_sample_type, double_side);
 }
 

--- a/soft_renderer/functional/soft_rasterize.py
+++ b/soft_renderer/functional/soft_rasterize.py
@@ -9,7 +9,7 @@ import soft_renderer.cuda.soft_rasterize as soft_rasterize_cuda
 class SoftRasterizeFunction(Function):
 
     @staticmethod
-    def forward(ctx, face_vertices, textures, image_size=256,
+    def forward(ctx, face_vertices, textures, image_size=(256, 256),
                 background_color=[0, 0, 0], near=1, far=100,
                 fill_back=True, eps=1e-3,
                 sigma_val=1e-5, dist_func='euclidean', dist_eps=1e-4,
@@ -49,11 +49,11 @@ class SoftRasterizeFunction(Function):
             dtype=torch.float32,
             device=ctx.device)  # [inv*9, sym*9, obt*3, 0*6]
         aggrs_info = torch.zeros(
-            (ctx.batch_size, 2, ctx.image_size, ctx.image_size),
+            (ctx.batch_size, 2, ctx.image_size[1], ctx.image_size[0]),
             dtype=torch.float32,
             device=ctx.device)
         soft_colors = torch.ones(
-            (ctx.batch_size, 4, ctx.image_size, ctx.image_size),
+            (ctx.batch_size, 4, ctx.image_size[1], ctx.image_size[0]),
             dtype=torch.float32,
             device=ctx.device)
 
@@ -65,7 +65,7 @@ class SoftRasterizeFunction(Function):
             soft_rasterize_cuda.forward_soft_rasterize(face_vertices, textures,
                                                        faces_info, aggrs_info,
                                                        soft_colors,
-                                                       image_size, near, far, eps,
+                                                       image_size[0], image_size[1], near, far, eps,
                                                        sigma_val, ctx.func_dist_type, ctx.dist_eps,
                                                        gamma_val, ctx.func_rgb_type, ctx.func_alpha_type,
                                                        ctx.texture_type, fill_back)
@@ -103,7 +103,7 @@ class SoftRasterizeFunction(Function):
             soft_rasterize_cuda.backward_soft_rasterize(face_vertices, textures, soft_colors,
                                                         faces_info, aggrs_info,
                                                         grad_faces, grad_textures, grad_soft_colors,
-                                                        image_size, near, far, eps,
+                                                        image_size[0], image_size[1], near, far, eps,
                                                         sigma_val, func_dist_type, dist_eps,
                                                         gamma_val, func_rgb_type, func_alpha_type,
                                                         texture_type, fill_back)
@@ -111,7 +111,7 @@ class SoftRasterizeFunction(Function):
         return grad_faces, grad_textures, None, None, None, None, None, None, None, None, None, None, None, None, None
 
 
-def soft_rasterize(face_vertices, textures, image_size=256,
+def soft_rasterize(face_vertices, textures, image_size=(256, 256),
                    background_color=[0, 0, 0], near=1, far=100,
                    fill_back=True, eps=1e-3,
                    sigma_val=1e-5, dist_func='euclidean', dist_eps=1e-4,

--- a/soft_renderer/rasterizer.py
+++ b/soft_renderer/rasterizer.py
@@ -8,7 +8,7 @@ import soft_renderer.functional as srf
 
 
 class SoftRasterizer(nn.Module):
-    def __init__(self, image_size=256, background_color=[0, 0, 0], near=1, far=100,
+    def __init__(self, image_size=(256, 256), background_color=[0, 0, 0], near=1, far=100,
                  anti_aliasing=False, fill_back=False, eps=1e-3,
                  sigma_val=1e-5, dist_func='euclidean', dist_eps=1e-4,
                  gamma_val=1e-4, aggr_func_rgb='softmax', aggr_func_alpha='prod',
@@ -46,7 +46,10 @@ class SoftRasterizer(nn.Module):
         self.gamma_val = gamma
 
     def forward(self, mesh, mode=None):
-        image_size = self.image_size * (2 if self.anti_aliasing else 1)
+        image_size = self.image_size
+        if self.anti_aliasing:
+            image_size[0] *= 2
+            image_size[1] *= 2
 
         images = srf.soft_rasterize(mesh.face_vertices, mesh.face_textures, image_size,
                                     self.background_color, self.near, self.far,


### PR DESCRIPTION
This is a working draft of a PR that adds support for rasterizing to images of non-square size (width != height).

I've modified the CUDA kernels and C++ functions, changed the Rasterizer class to accept (width, height) tuple for image_size, and have confirmed that demo_render.py is working with other image sizes. I've yet not tested the other demos though, and there might be other places in the Python API that I've missed that needs to be changed as well.

This effectively solves issue #34.

The things left to do:

- [x] Add support for non-square image sizes in C++/CUDA land
- [x] Rasterizer class accepts (width, height) tuple for image_size parameter
- [ ] Modify other places in the Python API (such as the Camera class) to also work with non-square resolution
- [ ] Check if all Python demos are working as expected (even with different image resolutions)

Since I have limited spare time, any help on completing this PR can be appreciated (especially modifying and testing it on the Python API side).